### PR TITLE
connectToはサーバー設定時には必須の値でかつコマンドの判定にconnectToのlengthを使うので、defaultValueを…

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -49,7 +49,7 @@ func init() {
 		&FlagOptions.ConnectTo,
 		"connect-to",
 		"c",
-		"127.0.0.1",
+		"",
 		"target server ip to connect",
 	)
 }


### PR DESCRIPTION
…空白の文字列にした